### PR TITLE
Use requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+*.db

--- a/main.py
+++ b/main.py
@@ -17,27 +17,11 @@ import error_handling
 from constants import Constants, YoumuEmbed
 import sauces
 import sys
-print(sys.modules.keys())
-try:
-	import discord
-	from discord.ext import commands
-except ImportError: 
-	os.system('pip install discord')
-	import discord
-	from discord.ext import commands
-
-try: from skingrabber import skingrabber
-except ImportError: os.system('pip install skingrabber')
-
-try: from discord_slash import SlashCommand, SlashContext
-except ImportError:
-	os.system('pip install discord-py-slash-command')
-	from discord_slash import SlashCommand, SlashContext
-
-try: from discord_components import DiscordComponents, Button, ButtonStyle
-except ImportError:
-	os.system('pip install discord-components')
-	from discord_components import DiscordComponents, Button, ButtonStyle
+import discord
+from discord.ext import commands
+from skingrabber import skingrabber
+from discord_slash import SlashCommand, SlashContext
+from discord_components import DiscordComponents, Button, ButtonStyle
 
 TOKEN = os.getenv('TOKEN')
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,11 @@ except ImportError:
 	os.system('pip install discord-components')
 	from discord_components import DiscordComponents, Button, ButtonStyle
 
+TOKEN = os.getenv('TOKEN')
+
+if TOKEN is None:
+	raise ValueError("Please set your discord bot token to the TOKEN enviroment variable")
+
 db=LevelDB('Levels')
 bot_channel_db=BotChannelDB('botchannels')
 xp_channel_db=BotChannelDB('xpchannels')
@@ -642,4 +647,4 @@ async def owner(ctx, guild_id: int, *, message):
 
 
 keep_alive()
-bot.run(os.getenv('TOKEN'))
+bot.run(TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+discord
+skingrabber
+discord-py-slash-command
+discord-components
+flask
+ply
+pillow
+bs4
+lxml

--- a/sauces.py
+++ b/sauces.py
@@ -6,8 +6,6 @@ import random
 import asyncio
 import os
 import sys
-if not 'lxml' in list(sys.modules.keys()):
-	os.system('pip install lxml') #need
 
 booruappend = ''
 booru = 'gelbooru.com'

--- a/special_tasks.py
+++ b/special_tasks.py
@@ -2,10 +2,7 @@ import os
 import discord
 import asyncio 
 from random import choice
-try: from discord_components import DiscordComponents, Button, ButtonStyle
-except ImportError:
-	os.system('pip install discord-components')
-	from discord_components import DiscordComponents, Button, ButtonStyle
+from discord_components import DiscordComponents, Button, ButtonStyle
 
 async def presence_hourly(bot, presences, last_presence, presence_is_looping):
 	if not presence_is_looping: #prevent from looping multiple times If on_ready() is called multiple times

--- a/tictactoe.py
+++ b/tictactoe.py
@@ -2,10 +2,7 @@ import os
 import asyncio
 import discord
 from typing import Union
-try: from discord_components import Button, ButtonStyle
-except ImportError:
-	os.system('pip install discord-components')
-	from discord_components import Button, ButtonStyle
+from discord_components import Button, ButtonStyle
 
 class Tile: 
 	def __init__(self, owner:Union[discord.Member, None]=None):

--- a/uno.py
+++ b/uno.py
@@ -2,10 +2,7 @@ import os
 import asyncio
 import discord
 from random import choice, choices
-try: from discord_components import Button, ButtonStyle
-except ImportError:
-	os.system('pip install discord-components')
-	from discord_components import Button, ButtonStyle
+from discord_components import Button, ButtonStyle
 
 class Card:
 	weights={


### PR DESCRIPTION
Instead of programmatically installing the package on import error, you should be specifying the required packages in a `requirements.txt`file at the top of your project.

This has many benefits, some of them are:
  - Easily obtaining the required packages for a new environment with `pip install -r requirements.txt`
  - Dependency check by GitHub
 