### PR TITLE
Use argparse to configure the status server

### DIFF
--- a/keep_alive.py
+++ b/keep_alive.py
@@ -12,7 +12,7 @@ routes = web.RouteTableDef()
 
 
 @routes.get("/")
-async def home():
+async def home(request):
     return web.Response(text="Bot is online")
 
 

--- a/keep_alive.py
+++ b/keep_alive.py
@@ -5,6 +5,8 @@
 
 import asyncio
 from aiohttp import web
+import typing
+import pathlib
 
 routes = web.RouteTableDef()
 
@@ -14,12 +16,15 @@ async def home():
     return web.Response(text="Bot is online")
 
 
-async def keep_alive():
+async def keep_alive(address: typing.Union[pathlib.Path, tuple[str, int]]) -> None:
     app = web.Application()
     app.add_routes(routes)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '0.0.0.0', 8000)
+    if isinstance(address, tuple):
+        site = web.TCPSite(runner, address[0], address[1])
+    else:
+        site = web.UnixSite(runner, address)
     await site.start()
     print(f"Listening for HTTP connections in {site.name}")
     try:


### PR DESCRIPTION
By default the status server won't start;
You should either pass `--unix path` or `--tcp address port` to enable it.

This allows the status server to also accept connections
via an unix, ipv6/tcp or ipv4/tcp socket, with a configurable address and port.

**For the previous behavior add `--tcp 0.0.0.0 8000` to your argument list.**