### PR TITLE
Use argparse to configure the status server

### DIFF
--- a/keep_alive.py
+++ b/keep_alive.py
@@ -23,7 +23,7 @@ async def Runner(runner: web.BaseRunner):
     try:
         yield runner
     finally:
-        runner.cleanup()
+        await runner.cleanup()
 
 
 async def keep_alive(address: typing.Union[pathlib.Path, tuple[str, int], None]) -> None:

--- a/keep_alive.py
+++ b/keep_alive.py
@@ -5,6 +5,8 @@
 
 import asyncio
 from aiohttp import web
+import typing
+import pathlib
 
 routes = web.RouteTableDef()
 
@@ -14,12 +16,15 @@ async def home(req):
     return web.Response(text="Bot is online")
 
 
-async def keep_alive():
+async def keep_alive(address: typing.Union[pathlib.Path, tuple[str, int]]) -> None:
     app = web.Application()
     app.add_routes(routes)
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, '0.0.0.0', 8000)
+    if isinstance(address, tuple):
+        site = web.TCPSite(runner, address[0], int(address[1]))
+    else:
+        site = web.UnixSite(runner, str(address))
     await site.start()
     print(f"Listening for HTTP connections in {site.name}")
     try:

--- a/main.py
+++ b/main.py
@@ -70,12 +70,16 @@ def is_botchannel(ctx):
 @bot.event
 async def on_ready():
 	print(f'{bot.user.name} has connected')
+	
 	if args.unix:
 		address = args.unix[0]
-	else:
+	elif args.tcp:
 		address = tuple(args.tcp)
-	asyncio.create_task(keep_alive(address), name="status server")
-	print("Status server is starting")
+	else:
+		address = None
+	if address is not None:
+		asyncio.create_task(keep_alive(address), name="status server")
+		print("Status server is starting")
 	#print([guild for guild in bot.guilds])
 	global guild_ids
 	guild_ids=[guild.id for guild in bot.guilds]


### PR DESCRIPTION
This fixes issue #4

By default the status server won't start;
You should either pass `--unix path` or `--tcp address port` to enable it.

This allows the status server to also accept connections
via an unix, ipv6/tcp or ipv4/tcp socket, with a configurable address and port.

**For the previous behavior add `--tcp 0.0.0.0 8000` to your argument list.**